### PR TITLE
feat: adding support for new "flagged" review status

### DIFF
--- a/protos/annonars/clinvar/minimal.proto
+++ b/protos/annonars/clinvar/minimal.proto
@@ -56,6 +56,10 @@ enum ReviewStatus {
     REVIEW_STATUS_NO_ASSERTION_CRITERIA_PROVIDED = 6;
     // "no assertion provided"
     REVIEW_STATUS_NO_ASSERTION_PROVIDED = 7;
+    // "flagged submission"
+    REVIEW_STATUS_FLAGGED_SUBMISSION = 8;
+    // "no classifications from unflagged records"
+    REVIEW_STATUS_NO_CLASSIFICATIONS_FROM_UNFLAGGED_RECORDS = 9;
 }
 
 // Record for storing information about a reference clinvar assertion.

--- a/src/clinvar_minimal/cli/import.rs
+++ b/src/clinvar_minimal/cli/import.rs
@@ -213,15 +213,19 @@ mod test {
     use clap_verbosity_flag::Verbosity;
     use temp_testdir::TempDir;
 
-    #[test]
-    fn smoke_test_import_jsonl() {
+    #[tracing_test::traced_test]
+    #[rstest::rstest]
+    #[case("tests/clinvar-minimal/clinvar-seqvars-grch37-tgds.jsonl")]
+    #[case("tests/clinvar-minimal/clinvar-seqvars-grch37-flagged.jsonl")]
+    #[case("tests/clinvar-minimal/clinvar-seqvars-grch37-no-unflagged.jsonl")]
+    fn smoke_test_import_jsonl(#[case] path_in_jsonl: &str) {
         let tmp_dir = TempDir::default();
         let common = common::cli::Args {
             verbose: Verbosity::new(1, 0),
         };
         let args = Args {
             genome_release: common::cli::GenomeRelease::Grch37,
-            path_in_jsonl: String::from("tests/clinvar-minimal/clinvar-seqvars-grch37-tgds.jsonl"),
+            path_in_jsonl: path_in_jsonl.into(),
             path_out_rocksdb: format!("{}", tmp_dir.join("out-rocksdb").display()),
             cf_name: String::from("clinvar"),
             cf_name_by_accession: String::from("clinvar_by_accession"),

--- a/src/clinvar_minimal/cli/reading.rs
+++ b/src/clinvar_minimal/cli/reading.rs
@@ -211,6 +211,10 @@ pub enum ReviewStatus {
     NoAssertionCriteriaProvided,
     /// "no assertion provided"
     NoAssertionProvided,
+    /// "flagged submission",
+    FlaggedSubmission,
+    /// "no classifications from unflagged records",
+    NoClassificationsFromUnflaggedRecords,
 }
 
 impl Display for ReviewStatus {
@@ -231,6 +235,10 @@ impl Display for ReviewStatus {
             ReviewStatus::NoAssertionProvided => write!(f, "no assertion provided"),
             ReviewStatus::PracticeGuideline => write!(f, "practice guideline"),
             ReviewStatus::ReviewedByExpertPanel => write!(f, "reviewed by expert panel"),
+            ReviewStatus::FlaggedSubmission => write!(f, "flagged submission"),
+            ReviewStatus::NoClassificationsFromUnflaggedRecords => {
+                write!(f, "no classifications from unflagged records")
+            }
         }
     }
 }
@@ -253,6 +261,10 @@ impl FromStr for ReviewStatus {
             "no assertion provided" => Ok(ReviewStatus::NoAssertionProvided),
             "practice guideline" => Ok(ReviewStatus::PracticeGuideline),
             "reviewed by expert panel" => Ok(ReviewStatus::ReviewedByExpertPanel),
+            "flagged submission" => Ok(ReviewStatus::FlaggedSubmission),
+            "no classifications from unflagged records" => {
+                Ok(ReviewStatus::NoClassificationsFromUnflaggedRecords)
+            }
             _ => anyhow::bail!("Unknown review status: {}", s),
         }
     }
@@ -295,6 +307,8 @@ impl From<ReviewStatus> for crate::pbs::clinvar::minimal::ReviewStatus {
             }
             ReviewStatus::ReviewedByExpertPanel => crate::pbs::clinvar::minimal::ReviewStatus::ReviewedByExpertPanel,
             ReviewStatus::PracticeGuideline => crate::pbs::clinvar::minimal::ReviewStatus::PracticeGuideline,
+            ReviewStatus::FlaggedSubmission => crate::pbs::clinvar::minimal::ReviewStatus::FlaggedSubmission,
+            ReviewStatus::NoClassificationsFromUnflaggedRecords => crate::pbs::clinvar::minimal::ReviewStatus::NoClassificationsFromUnflaggedRecords,
         }
     }
 }
@@ -309,6 +323,8 @@ impl From<i32> for ReviewStatus {
             5 => ReviewStatus::CriteriaProvidedConflictingInterpretations,
             6 => ReviewStatus::NoAssertionCriteriaProvided,
             7 => ReviewStatus::NoAssertionProvided,
+            8 => ReviewStatus::FlaggedSubmission,
+            9 => ReviewStatus::NoClassificationsFromUnflaggedRecords,
             _ => unreachable!(),
         }
     }


### PR DESCRIPTION
Recently, ClinVar introduced the new review status values from below. We now have support for them.

- `"flagged submission"`
- `"no classifications from unflagged records"`